### PR TITLE
feat(kparser): be able to parse attribute on top of enums

### DIFF
--- a/kproc-examples/src/main.rs
+++ b/kproc-examples/src/main.rs
@@ -75,6 +75,20 @@ enum Message {
     ChangeColor(i32, i32, i32),
 }
 
+#[derive(EnumParser)]
+enum MessageWithAttr {
+    #[cli]
+    Quit,
+    #[cli = "foo"]
+    Move {
+        x: i32,
+        y: i32,
+    },
+    #[cli(help = "this is an helper message")]
+    Write(String),
+    ChangeColor(i32, i32, i32),
+}
+
 struct ForImplDerive {}
 
 /// this is a impl doc

--- a/kproc-macros-examples/src/lib.rs
+++ b/kproc-macros-examples/src/lib.rs
@@ -25,7 +25,7 @@ pub fn derive_rust(input: TokenStream) -> TokenStream {
     toks
 }
 
-#[proc_macro_derive(EnumParser)]
+#[proc_macro_derive(EnumParser, attributes(cli))]
 pub fn derive_enum(stream: TokenStream) -> TokenStream {
     let tracer = Tracer {};
     let parser = RustParser::with_tracer(&tracer);

--- a/kproc-parser/src/rust/core.rs
+++ b/kproc-parser/src/rust/core.rs
@@ -104,8 +104,11 @@ pub fn check_and_parse_bounds(
                         );
                         trace!(tracer, "bound found `{:?}`", bound);
                         let Some(generic) = generic.as_mut() else {
-                            return Err(build_error!(inner_stream.peek().clone(), "concatenation bound `+` on generic used in the wrong way"));
-                         };
+                            return Err(build_error!(
+                                inner_stream.peek().clone(),
+                                "concatenation bound `+` on generic used in the wrong way"
+                            ));
+                        };
                         generic.add_bound(bound);
                     }
                     _ => {

--- a/kproc-parser/src/rust/kattr.rs
+++ b/kproc-parser/src/rust/kattr.rs
@@ -1,10 +1,31 @@
 use std::collections::HashMap;
 
-use crate::kparser::KParserTracer;
+use crate::kparser::{KParserError, KParserTracer};
 use crate::kproc_macros::KTokenStream;
 use crate::proc_macro::TokenTree;
 use crate::rust::ast_nodes::{AttrToken, AttributeToken, CondAttributeToken};
+use crate::{build_error, kparser};
+use crate::{check, trace};
 
+use super::ast_nodes::{Attr, AttributeV2Token};
+
+pub mod macros {
+    #[macro_export]
+    macro_rules! parse_attributes {
+        ($stream:expr, $tracer:expr ) => {
+            check_and_parser_attributes_v2($stream, $tracer)
+        };
+    }
+
+    pub use parse_attributes;
+}
+
+pub mod prelude {
+    pub use super::check_and_parser_attributes_v2;
+    pub use super::macros::*;
+}
+
+#[deprecated(note = "Pleas use the check_and_parse_cond_attribute! macro")]
 pub fn check_and_parse_cond_attribute(
     ast: &mut KTokenStream,
     tracer: &dyn KParserTracer,
@@ -47,6 +68,7 @@ pub fn check_and_parse_cond_attribute(
     attrs
 }
 
+#[deprecated(note = "Pleas use the check_and_parse_cond_attribute! macro")]
 pub fn check_and_parse_attribute(ast: &mut KTokenStream) -> Option<AttributeToken> {
     let name = ast.advance();
     // FIXME: check if it is a valid name
@@ -59,4 +81,86 @@ pub fn check_and_parse_attribute(ast: &mut KTokenStream) -> Option<AttributeToke
         });
     }
     Some(AttributeToken { name, value: None })
+}
+
+pub fn check_and_parser_attributes_v2<T: KParserTracer + ?Sized>(
+    stream: &mut KTokenStream,
+    tracer: &T,
+) -> kparser::Result<HashMap<String, AttributeV2Token>> {
+    trace!(tracer, "checking and parsing attributes");
+
+    let mut attrs = HashMap::new();
+    // Parsing case where there are multiple attributes on one fields
+    while stream.match_tok("#") {
+        check!("#", stream.advance())?;
+        let inner_attr = stream.match_tok("!").then(|| stream.next());
+        let (identifier, attr) = check_and_parse_attribute_v2(stream, tracer)?;
+        let attr = if inner_attr.is_some() {
+            AttributeV2Token::InnerAttribute(attr)
+        } else {
+            AttributeV2Token::OuterAttribute(attr)
+        };
+        attrs.insert(identifier, attr);
+    }
+    Ok(attrs)
+}
+
+pub fn check_and_parse_attribute_v2<T: KParserTracer + ?Sized>(
+    stream: &mut KTokenStream,
+    tracer: &T,
+) -> kparser::Result<(String, Attr)> {
+    // unwrap the group given by the `#[]`
+    let mut inner_stream = stream.to_ktoken_stream();
+    trace!(
+        tracer,
+        "Attribute parsing: inner stream `{:?}`",
+        inner_stream
+    );
+    let raw_attr = stream.advance();
+    let identifier = inner_stream.advance();
+    if inner_stream.is_end() {
+        return Ok((
+            identifier.to_string(),
+            Attr {
+                path: Vec::new(),
+                identifier,
+                value: None,
+                raw_attr,
+            },
+        ));
+    }
+    let (_, value) = match inner_stream.peek() {
+        TokenTree::Group(_) => check_and_parse_attribute_v2(&mut inner_stream, tracer)?,
+        TokenTree::Punct(punt) => {
+            trace!(tracer, "Attribute parsing: separator `{punt}`");
+            inner_stream.next();
+            let value = inner_stream.advance();
+            (
+                String::new(),
+                Attr {
+                    path: Vec::new(),
+                    identifier: value.clone(),
+                    value: None,
+                    raw_attr: value,
+                },
+            )
+        }
+        // FIXME in case of multiple attribute this will panic
+        _ => {
+            return Err(build_error!(
+                inner_stream.peek().clone(),
+                "Error while parsing an attribute, token `{}` not expected",
+                inner_stream.peek()
+            ))
+        }
+    };
+    Ok((
+        identifier.to_string(),
+        Attr {
+            path: Vec::new(),
+            identifier,
+            value: Some(value.into()),
+            raw_attr,
+        },
+    ))
 }


### PR DESCRIPTION
This is still missing one attribute have multiple values like

`#[cli(key=value, key=value)`